### PR TITLE
Handle catkin packages.

### DIFF
--- a/before_install
+++ b/before_install
@@ -44,6 +44,25 @@ git_clone="git clone --quiet --recursive"
 echo "Environment:"
 env
 
+# catkin_git_dependency
+# --------------------
+#
+catkin_git_dependency()
+{
+    _string=$1
+    git_dep=${_string%%:*}
+    git_dep_branch=${_string##*:}
+    # For ROS packages, the default version is named after the ROS distro.
+    if [ "$git_dep_branch" == "$git_dep" ]; then
+	git_dep_branch="$ROS_DISTRO"
+    fi
+    echo "--> Getting $git_dep (branch $git_dep_branch)"
+    CATKIN_WORKSPACE=$build_dir/..
+    cd $CATKIN_WORKSPACE/src
+    $git_clone -b $git_dep_branch "git://github.com/$git_dep" "$git_dep"
+}
+
+
 # build_git_dependency
 # --------------------
 #
@@ -178,6 +197,12 @@ else
     fi
 
     # and we build directly dependencies from the Git repository
+    if `! test x${ROS_GIT_DEPENDENCIES} = x`; then
+      for package in ${ROS_GIT_DEPENDENCIES}; do
+        catkin_git_dependency "$package"
+      done
+    fi
+
     cd $root_dir
     for package in ${GIT_DEPENDENCIES}; do
 	build_git_dependency "$package"

--- a/build
+++ b/build
@@ -110,6 +110,41 @@ debian_build_package()
 }
 
 
+# build_catkin_package
+# --------------------
+#
+# build all the packages using catkin_make.
+# Also check the installation (catkin_make install)
+# and check whether the catkin package is well written (catkin_lint)
+build_catkin_package()
+{
+    . /opt/ros/${ROS_DISTRO}/setup.sh
+    CATKIN_WORKSPACE=$build_dir/..
+
+    # Limit the number of parallel jobs when running catkin_make
+    if `test x${PARALLEL_JOBS} = x`; then
+	export ROS_PARALLEL_JOBS='-j 1'
+    else
+	export ROS_PARALLEL_JOBS='-j ${PARALLEL_JOBS}'
+    fi
+
+
+    cd $CATKIN_WORKSPACE
+    catkin_make
+    for pack in `ls -d ./src/*/ ./src/*/*/`; do
+	if test -f $pack/package.xml; then
+	    rosdoc_lite $pack
+	fi
+    done
+    catkin_make install
+
+    # run catkin_lint on every directory.
+    if `test x${ALLOW_CATKINLINT_FAILURE} = x`; then
+	ALLOW_CATKINLINT_FAILURE=false
+    fi
+    catkin_lint `ls -d ./src/*/ ./src/*/*/`  || ${ALLOW_CATKINLINT_FAILURE}
+}
+
 # Realize a normal build in all branches except the one containing a
 # debian/ folder.
 if [ -d debian ]; then
@@ -124,7 +159,20 @@ else
 	echo "skipping this build"
 	exit 0
     fi
-    build_package
+
+    # checking if it is a ros folder. Taking appropriate measure.
+    #The current repository is a package
+    if [ -e package.xml ]; then
+      build_catkin_package
+    else
+      #The current repository is a stack
+      res=`ls -d ./*/package.xml`
+      if `test 'x${res}' != 'x'`; then
+        build_catkin_package
+      else
+        build_package
+      fi
+    fi
 fi
 
 # End debug mode

--- a/common.sh
+++ b/common.sh
@@ -21,6 +21,10 @@ fi
 git_clone="git clone --quiet --recursive"
 
 # Setup environment variables.
+if [ -d /opt/ros ]; then
+  . /opt/ros/${ROS_DISTRO}/setup.sh
+fi
+
 export LD_LIBRARY_PATH="$install_dir/lib:$LD_LIBRARY_PATH"
 export LTDL_LIBRARY_PATH="$install_dir/lib:$LTDL_LIBRARY_PATH"
 export PKG_CONFIG_PATH="$install_dir/lib/pkgconfig:$PKG_CONFIG_PATH"

--- a/dependencies/catkin
+++ b/dependencies/catkin
@@ -1,0 +1,28 @@
+#!/bin/bash
+. .travis/common.sh
+
+# If the ros version is not defined, quit.
+if `test x${ROS_DISTRO} = x`; then
+  exit 0
+fi
+
+sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
+wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
+sudo apt-get update
+
+if `test x${ROS_DISTRO} = xhydro`; then
+  sudo apt-get install ros-hydro-ros-base ros-hydro-rosdoc-lite python-catkin-lint
+elif `test x${ROS_DISTRO} = xgroovy`; then
+  sudo apt-get install ros-groovy-ros-base ros-groovy-rosdoc-lite python-catkin-lint
+else
+  echo "ROS distribution unkown, exiting" + ${ROS_DISTRO}
+	exit 1
+fi
+. /opt/ros/${ROS_DISTRO}/setup.sh
+
+# workspace
+CATKIN_WORKSPACE=$build_dir/..
+ln -s $root_dir/.. $CATKIN_WORKSPACE/src
+cd $CATKIN_WORKSPACE/src
+catkin_init_workspace
+

--- a/travis.yml.in
+++ b/travis.yml.in
@@ -6,6 +6,9 @@ env:
   - @ENCRYPTED_GNUPG_PASSPHRASE@
   - @APT_DEPENDENCIES@
   - @GIT_DEPENDENCIES@
+  - @ROS_GIT_DEPENDENCIES@
+  - @ROS_DISTRO@
+  - @PARALLEL_JOBS@
   - DEBSIGN_KEYID=5AE5CD75
   matrix: # this section is for the Debian branch only
   - DIST=unstable


### PR DESCRIPTION
This PR allows to handle catkin packages, that will be compiled using catkin_make.
The installation and the generation of the doc are also handled, as well as catkin_lite, that checks whether the 
package is well written. The failure for catkin_lite can be allowed with an option.

This PR has been tested there:
https://travis-ci.org/francois-keith/dynamic_graph_bridge/
