### PR TITLE
Topic/fix catkin dependencies

### DIFF
--- a/after_success
+++ b/after_success
@@ -90,14 +90,7 @@ push_note()
   HEAD=`git rev-parse HEAD`
   notes_msg="Successful build.\n----\n\nDependencies commit id:"
   for package in ${GIT_DEPENDENCIES}; do
-    git_dep=${_string%%;*}
-    git_dep_uri_base=${git_dep%%:*}
-    if [ "$git_dep_uri_base" == "$git_dep" ]; then
-      git_dep_uri="git://github.com/$git_dep"
-    else
-      git_dep_uri=$git_dep
-      git_dep=${git_dep##*:}
-    fi
+    git_dependency_parsing $package
     cd $build_dir/$git_dep
     commitid=`git rev-parse HEAD || echo unknown`
     notes_msg="${notes_msg} $git_dep : $commitid\n"
@@ -105,7 +98,7 @@ push_note()
   cd $root_dir
   git fetch --quiet --force origin refs/notes/jrl-ci:refs/notes/jrl-ci || true
   git notes --ref=jrl-ci add -f -m "$(echo "${notes_msg}")" $HEAD
-  git push origin refs/notes/travis --force
+  git push origin refs/notes/jrl-ci --force
 }
 
 #########################

--- a/before_install
+++ b/before_install
@@ -129,8 +129,8 @@ catkin_build_workspace()
 #
 # Build a dependency directly from the Git development tree.
 # First argument: repository's GitHub URL or repository's URI + optional branch
-# For example: "jrl-umi3218/jrl-travis" or "jrl-umi3218/jrl-travis;dev"
-# Or: user@host:path/to/repo or git@github.com:organization/repo;branch
+# For example: "jrl-umi3218/jrl-travis" or "jrl-umi3218/jrl-travis#dev"
+# Or: user@host:path/to/repo or git@github.com:organization/repo#branch
 build_git_dependency()
 {
   git_dependency_parsing $1

--- a/before_install
+++ b/before_install
@@ -175,7 +175,7 @@ install_dependencies()
   for package in ${ROS_GIT_DEPENDENCIES}; do
     catkin_git_dependency "$package"
   done
-  if `test x${ROS_GIT_DEPENDENCIES} != x`; then
+  if `test "x${ROS_GIT_DEPENDENCIES}" != x`; then
     catkin_build_workspace
   fi
 

--- a/before_install
+++ b/before_install
@@ -102,19 +102,16 @@ setup_pbuilder()
 # catkin_git_dependency
 # --------------------
 #
+# Clone catkin package into the workspace
+# See arguments of build_git_dependency
+# Branch defaults to $ROS_DISTRO instead of master
 catkin_git_dependency()
 {
-    _string=$1
-    git_dep=${_string%%:*}
-    git_dep_branch=${_string##*:}
-    # For ROS packages, the default version is named after the ROS distro.
-    if [ "$git_dep_branch" == "$git_dep" ]; then
-        git_dep_branch="$ROS_DISTRO"
-    fi
-    echo "--> Getting $git_dep (branch $git_dep_branch)"
-    CATKIN_WORKSPACE=$build_dir/..
-    cd $CATKIN_WORKSPACE/src
-    $git_clone -b $git_dep_branch "git://github.com/$git_dep" "$git_dep"
+  git_dependency_parsing $1 $ROS_DISTRO
+  echo "--> Getting $git_dep (branch $git_dep_branch)"
+  CATKIN_WORKSPACE=$build_dir/..
+  cd $CATKIN_WORKSPACE/src
+  $git_clone -b $git_dep_branch "$git_dep_uri" "$git_dep"
 }
 
 # build_git_dependency
@@ -126,27 +123,15 @@ catkin_git_dependency()
 # Or: user@host:path/to/repo or git@github.com:organization/repo;branch
 build_git_dependency()
 {
-    _string=$1
-    git_dep=${_string%%;*}
-    git_dep_branch=${_string##*;}
-    if [ "$git_dep_branch" == "$git_dep" ]; then
-        git_dep_branch="master"
-    fi
-    git_dep_uri_base=${git_dep%%:*}
-    if [ "$git_dep_uri_base" == "$git_dep" ]; then
-      git_dep_uri="git://github.com/$git_dep"
-    else
-      git_dep_uri=$git_dep
-      git_dep=${git_dep##*:}
-    fi
-    echo "--> Compiling $git_dep (branch $git_dep_branch)"
-    cd "$build_dir"
-    mkdir -p "$git_dep"
-    $git_clone -b $git_dep_branch "$git_dep_uri" "$git_dep"
-    cd "$git_dep"
-    cmake . -DCMAKE_INSTALL_PREFIX:STRING="$install_dir" \
-            -DDISABLE_TESTS:BOOL=ON
-    make install || make
+  git_dependency_parsing $1
+  echo "--> Compiling $git_dep (branch $git_dep_branch)"
+  cd "$build_dir"
+  mkdir -p "$git_dep"
+  $git_clone -b $git_dep_branch "$git_dep_uri" "$git_dep"
+  cd "$git_dep"
+  cmake . -DCMAKE_INSTALL_PREFIX:STRING="$install_dir" \
+          -DDISABLE_TESTS:BOOL=ON
+  make install || make
 }
 
 _osx_install_dependencies()

--- a/before_install
+++ b/before_install
@@ -114,6 +114,16 @@ catkin_git_dependency()
   $git_clone -b $git_dep_branch "$git_dep_uri" "$git_dep"
 }
 
+# catkin_build_workspace
+# ----------------------
+#
+# Build catkin workspace
+catkin_build_workspace()
+{
+  cd $CATKIN_WORKSPACE
+  catkin_make
+}
+
 # build_git_dependency
 # --------------------
 #
@@ -165,6 +175,9 @@ install_dependencies()
   for package in ${ROS_GIT_DEPENDENCIES}; do
     catkin_git_dependency "$package"
   done
+  if `test x${ROS_GIT_DEPENDENCIES} != x`; then
+    catkin_build_workspace
+  fi
 
   for package in ${GIT_DEPENDENCIES}; do
     build_git_dependency "$package"

--- a/before_install
+++ b/before_install
@@ -109,8 +109,8 @@ catkin_git_dependency()
 {
   git_dependency_parsing $1 $ROS_DISTRO
   echo "--> Getting $git_dep (branch $git_dep_branch)"
-  CATKIN_WORKSPACE=$build_dir/..
-  cd $CATKIN_WORKSPACE/src
+  CATKIN_DEP_WORKSPACE=/tmp/_ci/catkin_dep_ws
+  cd $CATKIN_DEP_WORKSPACE/src
   $git_clone -b $git_dep_branch "$git_dep_uri" "$git_dep"
 }
 
@@ -120,7 +120,8 @@ catkin_git_dependency()
 # Build catkin workspace
 catkin_build_workspace()
 {
-  cd $CATKIN_WORKSPACE
+  CATKIN_DEP_WORKSPACE=/tmp/_ci/catkin_dep_ws
+  cd $CATKIN_DEP_WORKSPACE
   catkin_make
 }
 

--- a/build
+++ b/build
@@ -111,7 +111,7 @@ build_catkin_package()
 
     # Limit the number of parallel jobs when running catkin_make
     PARALLEL_JOBS=${PARALLEL_JOBS:-1}
-    export ROS_PARALLEL_JOBS='-j ${PARALLEL_JOBS}'
+    export ROS_PARALLEL_JOBS="-j ${PARALLEL_JOBS}"
 
 
     cd $CATKIN_WORKSPACE

--- a/build
+++ b/build
@@ -98,6 +98,24 @@ debian_build_package()
 }
 
 
+# setup_ros_build_environment
+# ---------------------------
+#
+# Source ROS setup scripts if they exist
+setup_ros_build_environment()
+{
+  if [ -e /opt/ros/${ROS_DISTRO}/setup.sh ]; then
+    . /opt/ros/${ROS_DISTRO}/setup.sh
+  fi
+  CATKIN_DEP_WORKSPACE=/tmp/_ci/catkin_dep_ws
+  if [ -e ${CATKIN_DEP_WORKSPACE}/devel/setup.sh ]; then
+    . ${CATKIN_DEP_WORKSPACE}/devel/setup.sh
+  fi
+  # Limit the number of parallel jobs when running catkin_make
+  PARALLEL_JOBS=${PARALLEL_JOBS:-1}
+  export ROS_PARALLEL_JOBS="-j ${PARALLEL_JOBS}"
+}
+
 # build_catkin_package
 # --------------------
 #
@@ -106,13 +124,11 @@ debian_build_package()
 # and check whether the catkin package is well written (catkin_lint)
 build_catkin_package()
 {
-    . /opt/ros/${ROS_DISTRO}/setup.sh
+    # Main package workspace
     CATKIN_WORKSPACE=$build_dir/..
-
-    # Limit the number of parallel jobs when running catkin_make
-    PARALLEL_JOBS=${PARALLEL_JOBS:-1}
-    export ROS_PARALLEL_JOBS="-j ${PARALLEL_JOBS}"
-
+    ln -s $root_dir/.. $CATKIN_WORKSPACE/src
+    cd $CATKIN_WORKSPACE/src
+    catkin_init_workspace
 
     cd $CATKIN_WORKSPACE
     catkin_make
@@ -124,12 +140,11 @@ build_catkin_package()
     catkin_make install
 
     # run catkin_lint on every directory.
-    if `test x${ALLOW_CATKINLINT_FAILURE} = x`; then
-      ALLOW_CATKINLINT_FAILURE=false
-    fi
+    ALLOW_CATKINLINT_FAILURE=${ALLOW_CATKINLINT_FAILURE:-false}
     catkin_lint `ls -d ./src/*/ ./src/*/*/`  || ${ALLOW_CATKINLINT_FAILURE}
 }
 
+setup_ros_build_environment
 # Realize a normal build in all branches except the one containing a
 # debian/ folder.
 if [ -d debian ]; then

--- a/common.sh
+++ b/common.sh
@@ -46,6 +46,47 @@ case "$BASH_VERSION" in
         ;;
 esac
 
+########################################
+#        -- GLOBAL UTILITIES --        #
+########################################
+
+# git_dependency_parsing
+# ----------------------
+#
+# From an entry in GIT_DEPENDENCIES variable set git_dep, git_dep_uri and
+# git_dep_branch in the environment
+# For example given the input "jrl-umi3218/jrl-travis" the following variables
+# are defined in the environment:
+# - git_dep jrl-umi3218/jrl-travis
+# - git_dep_uri git://github.com/jrl-umi3218/jrl-traviss
+# - git_dep_branch master
+# Or, given the input git@github.com:jrl-umi3218/jrl-travis#thebranch
+# - git_dep jrl-umi3218/jrl-travis
+# - git_dep_uri git@github.com:jrl-umi3218/jrl-travis
+# - git_dep_branch thebranch
+# The second (optional) argument allows to defined the default branch (defaults
+# to master)
+git_dependency_parsing()
+{
+  _input=$1
+  export git_dep=${_input%%#*}
+  export git_dep_branch=${_input##*#}
+  if [ "$git_dep_branch" == "$git_dep" ]; then
+    if [ -e "$2" ]; then
+      export git_dep_branch=$2
+    else
+      export git_dep_branch="master"
+    fi
+  fi
+  git_dep_uri_base=${git_dep%%:*}
+  if [ "$git_dep_uri_base" == "$git_dep" ]; then
+    export git_dep_uri="git://github.com/$git_dep"
+  else
+    export git_dep_uri=$git_dep
+    export git_dep=${git_dep##*:}
+  fi
+}
+
 
 ########################################
 #    -- ENVIRONMENT MANIPULATION --    #

--- a/dependencies/catkin
+++ b/dependencies/catkin
@@ -24,9 +24,7 @@ else
 fi
 . /opt/ros/${ROS_DISTRO}/setup.sh
 
-# workspace
-CATKIN_WORKSPACE=$build_dir/..
-ln -s $root_dir/.. $CATKIN_WORKSPACE/src
-cd $CATKIN_WORKSPACE/src
-catkin_init_workspace
-
+# Dependencies workspace
+CATKIN_DEP_WORKSPACE=/tmp/_ci/catkin_dep_ws
+mkdir -p $CATKIN_DEP_WORKSPACE/src
+cd $CATKIN_DEP_WORKSPACE/src


### PR DESCRIPTION
* Factorize code to extract components of `*GIT_DEPENDENCIES`
* Change branch delimiter to `#` instead of `;`
* Build `ROS_GIT_DEPENDENCIES` before the main package (note: this is good for non-ROS packages that require a ROS dependency but a ROS package is built at before_install)
* Fix some bugs related to catkin/ROS packages