### PR TITLE
[Win32] Add AppVeyor support

### DIFF
--- a/appveyor.yml.in
+++ b/appveyor.yml.in
@@ -1,0 +1,42 @@
+version: 1.0.{build}
+os: Visual Studio 2015
+clone_folder: C:/devel-src/@PROJECT_NAME@
+# The following lines output the connection parameters for the RDE in AppVeyor
+# at the start of the build. Be advised that this may allow people to tinker
+# with your build
+# init:
+# - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+environment:
+  CI_OS_NAME: win32
+  CI_TOOL: appveyor
+# Dependencies should be a list of dependencies separated by spaces
+  CHOCO_DEPENDENCIES: @CHOCO_DEPENDENCIES@
+  GIT_DEPENDENCIES: @GIT_DEPENDENCIES@
+# Should be the same as clone_folder
+  PROJECT_SOURCE_DIR: C:/devel-src/@PROJECT_NAME@
+# Do not tinker with the variables below unless you know what you are doing
+  SOURCE_FOLDER: C:/devel-src
+  CMAKE_INSTALL_PREFIX: C:/devel
+  PATH: C:/devel/bin;C:\Libraries\boost_1_59_0\lib64-msvc-14.0;%PATH%
+  PKG_CONFIG_PATH: C:/devel/lib/pkgconfig
+  BOOST_ROOT: C:\Libraries\boost_1_59_0
+  BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14.0
+# N.B: empty lines here and in test_script are VERY important
+build_script:
+- ps: >-
+    Set-PSDebug -Trace 1
+
+    . ./.jrl-ci/functions.ps1
+
+    setup_build
+
+    ./.jrl-ci/dependencies/eigen-3.2.ps1
+
+    install_dependencies
+
+    build_project
+test_script:
+- cmd: >-
+    cd %PROJECT_SOURCE_DIR%
+
+    ctest

--- a/dependencies/eigen-3.2.ps1
+++ b/dependencies/eigen-3.2.ps1
@@ -1,0 +1,26 @@
+$EIGEN_VERSION="3.2.8"
+$EIGEN_HASH="07105f7124f9"
+
+cd $Env:SOURCE_FOLDER
+appveyor DownloadFile "http://bitbucket.org/eigen/eigen/get/$EIGEN_VERSION.zip"
+7z x "${EIGEN_VERSION}.zip" -o"${Env:SOURCE_FOLDER}\eigen" -r
+cd "${Env:SOURCE_FOLDER}\eigen\eigen-eigen-$EIGEN_HASH"
+md build
+cd build
+
+# Build, make and install Eigen
+cmake -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" ../
+msbuild INSTALL.vcxproj
+
+# Generate eigen3.pc
+$EIGEN3_PC_FILE="${Env:PKG_CONFIG_PATH}/eigen3.pc"
+echo "Name: Eigen3" | Out-File -Encoding ascii -FilePath $EIGEN3_PC_FILE
+echo "Description: A C++ template library for linear algebra: vectors, matrices, and related algorithms" | Out-File -Append -Encoding ascii -FilePath $EIGEN3_PC_FILE
+echo "Requires:" | Out-File -Append -Encoding ascii -FilePath $EIGEN3_PC_FILE
+echo "Version: $EIGEN_VERSION" | Out-File -Append -Encoding ascii -FilePath $EIGEN3_PC_FILE
+echo "Libs:" | Out-File -Append -Encoding ascii -FilePath $EIGEN3_PC_FILE
+echo "Cflags: -I${Env:CMAKE_INSTALL_PREFIX}/include/eigen3" | Out-File -Append -Encoding ascii -FilePath $EIGEN3_PC_FILE
+
+# Check install
+pkg-config --modversion "eigen3 >= ${EIGEN_VERSION}"
+pkg-config --cflags "eigen3 >= ${EIGEN_VERSION}"

--- a/functions.ps1
+++ b/functions.ps1
@@ -1,0 +1,99 @@
+function git_dependency_parsing
+{
+  $_input = $args[0].split('#');
+  if($args.length -gt 1)
+  {
+    $default_branch = $args[1];
+  }
+  else
+  {
+    $default_branch = "master";
+  }
+  Set-Variable -Name git_dep -Value $_input[0] -Scope Global;
+  Set-Variable -Name git_dep_branch -Value $default_branch -Scope Global;
+  if($_input.length -eq 2)
+  {
+    $git_dep_branch = $_input[1];
+    Set-Variable -Name git_dep_branch -Value $git_dep_branch -Scope Global;
+  }
+  $git_dep_uri_base = $git_dep.split(':')[0];
+  if($git_dep_uri_base -eq $git_dep)
+  {
+    $git_dep_uri = "git://github.com/" + $git_dep
+    Set-Variable -Name git_dep_uri -Value $git_dep_uri -Scope Global;
+  }
+  else
+  {
+    Set-Variable -Name git_dep_uri -Value $git_dep -Scope Global;
+    Set-Variable -Name git_dep -Value $git_dep.split(':')[1] -Scope Global;
+  }
+}
+
+function setup_directories
+{
+  md $env:CMAKE_INSTALL_PREFIX
+  if( -Not (Test-Path $Env:SOURCE_FOLDER) )
+  {
+    md $Env:SOURCE_FOLDER
+  }
+  if( -Not (Test-Path $Env:PKG_CONFIG_PATH) )
+  {
+    md $Env:PKG_CONFIG_PATH
+  }
+}
+
+function setup_pkg_config
+{
+  appveyor DownloadFile http://ftp.gnome.org/pub/gnome/binaries/win32/glib/2.28/glib_2.28.8-1_win32.zip
+  appveyor DownloadFile http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/pkg-config_0.26-1_win32.zip
+  appveyor DownloadFile http://ftp.gnome.org/pub/gnome/binaries/win32/dependencies/gettext-runtime_0.18.1.1-2_win32.zip
+  7z x glib_2.28.8-1_win32.zip -o"${env:CMAKE_INSTALL_PREFIX}" -r
+  7z x pkg-config_0.26-1_win32.zip -o"${env:CMAKE_INSTALL_PREFIX}" -r
+  7z x gettext-runtime_0.18.1.1-2_win32.zip -o"${env:CMAKE_INSTALL_PREFIX}" -r
+}
+
+function setup_build
+{
+  setup_directories
+  setup_pkg_config
+}
+
+function install_choco_dependencies
+{
+  ForEach($choco_dep in $Env:CHOCO_DEPENDENCIES.split(' '))
+  {
+    choco install $choco_dep
+  }
+}
+
+function install_git_dependencies
+{
+  ForEach($g_dep in $Env:GIT_DEPENDENCIES.split(' '))
+  {
+    cd $Env:SOURCE_FOLDER
+    git_dependency_parsing $g_dep
+    git clone -b "$git_dep_branch" "$git_dep_uri" "$git_dep"
+    cd $git_dep
+    git submodule update --init
+    md build
+    cd build
+    cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DPYTHON_BINDING=OFF
+    msbuild INSTALL.vcxproj
+  }
+}
+
+function install_dependencies
+{
+  install_choco_dependencies
+  install_git_dependencies
+}
+
+function build_project
+{
+  cd $Env:PROJECT_SOURCE_DIR
+  git submodule update --init
+  md build
+  cd build
+  cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DPYTHON_BINDING=OFF
+  msbuild INSTALL.vcxproj
+}


### PR DESCRIPTION
Hi all,

This adds (minimal) [AppVeyor](http://www.appveyor.com/) support into jrl-travis. Actually it shares no code with the rest of jrl-travis (as power shell has absolutely nothing to do with bash/posix shells) but I think it's still relevant to have it here as this potentially reduces the number of submodules in a project.

A few notes:

* Only supports Visual Studio 2015 Win64 builds
* Install pkg-config for windows on the system
* Same syntax for GIT_DEPENDENCIES (a list of repositories specifies a branch, `#` specifies a branch)
* Use CHOCO_DEPENDENCIES in place of apt/brew, see  [chocolatey website](https://chocolatey.org/)
* Boost libraries are installed on AppVeyor, the scripts are setting up the build system to use 1.59.0