### PR TITLE
Make coverage and cppcheck optional and dependant of the current branch

### DIFF
--- a/after_success
+++ b/after_success
@@ -113,7 +113,9 @@ elif [[ ${CI_OS_NAME} = linux ]]; then
       exit 0
     fi
 
-    generate_coverage_data
+    if [[ ";${DO_COVERAGE_ON_BRANCH};" == *";${TRAVIS_BRANCH};"* ]]; then
+      generate_coverage_data
+    fi
     # If it's not a fork or a pull request
     if `test x${CI_REPO_SLUG} = x${GH_REPO} -a ${CI_PULL_REQUEST} = false`; then
       set_push_uri

--- a/after_success
+++ b/after_success
@@ -113,9 +113,10 @@ elif [[ ${CI_OS_NAME} = linux ]]; then
       exit 0
     fi
 
-    if [[ ";${DO_COVERAGE_ON_BRANCH};" == *";${TRAVIS_BRANCH};"* ]]; then
+    if [[ ";${DO_COVERAGE_ON_BRANCH};" == *";${CI_BRANCH};"* ]]; then
       generate_coverage_data
     fi
+
     # If it's not a fork or a pull request
     if `test x${CI_REPO_SLUG} = x${GH_REPO} -a ${CI_PULL_REQUEST} = false`; then
       set_push_uri

--- a/build
+++ b/build
@@ -33,12 +33,14 @@ build_package()
     ALLOW_TESTSUITE_FAILURE=${ALLOW_TESTSUITE_FAILURE:-false}
     make test || ${ALLOW_TESTSUITE_FAILURE}
 
-    cppcheck --quiet --enable=all \
-      -I $root_dir/src -I $root_dir/tests -I $root_dir/include \
-      -I $root_dir/tests/shared-tests \
-      -I $build_dir/include -I $install_dir/include \
-      -i $build_dir/CMakeFiles \
-      $root_dir || true
+    if [[ ";${DO_CPPCHECK_ON_BRANCH};" == *";${TRAVIS_BRANCH};"* ]]; then
+      cppcheck --quiet --enable=all \
+        -I $root_dir/src -I $root_dir/tests -I $root_dir/include \
+        -I $root_dir/tests/shared-tests \
+        -I $build_dir/include -I $install_dir/include \
+        -i $build_dir/CMakeFiles \
+        $root_dir || true
+    fi
 }
 
 # debian_build_package

--- a/build
+++ b/build
@@ -15,11 +15,18 @@ build_package()
     echo "--> Building package..."
 
     cd "$build_dir"
-    cmake "$root_dir" -DCMAKE_INSTALL_PREFIX="$install_dir"	\
-      -DCMAKE_CXX_FLAGS="--coverage"				\
-      -DCMAKE_EXE_LINKER_FLAGS="--coverage"			\
-      -DCMAKE_MODULE_LINKER_FLAGS="--coverage"		\
-      ${CMAKE_ADDITIONAL_OPTIONS}
+
+    if [[ ";${DO_COVERAGE_ON_BRANCH};" == *";${TRAVIS_BRANCH};"* ]]; then
+      cmake "$root_dir" -DCMAKE_INSTALL_PREFIX="$install_dir"	\
+        -DCMAKE_CXX_FLAGS="--coverage"				\
+        -DCMAKE_EXE_LINKER_FLAGS="--coverage"			\
+        -DCMAKE_MODULE_LINKER_FLAGS="--coverage"		\
+        ${CMAKE_ADDITIONAL_OPTIONS}
+    else
+      cmake "$root_dir" -DCMAKE_INSTALL_PREFIX="$install_dir"	\
+        ${CMAKE_ADDITIONAL_OPTIONS}
+    fi
+
     ${MAKE_PREFIX} make
     make install
 

--- a/build
+++ b/build
@@ -16,7 +16,7 @@ build_package()
 
     cd "$build_dir"
 
-    if [[ ";${DO_COVERAGE_ON_BRANCH};" == *";${TRAVIS_BRANCH};"* ]]; then
+    if [[ ";${DO_COVERAGE_ON_BRANCH};" == *";${CI_BRANCH};"* ]]; then
       cmake "$root_dir" -DCMAKE_INSTALL_PREFIX="$install_dir"	\
         -DCMAKE_CXX_FLAGS="--coverage"				\
         -DCMAKE_EXE_LINKER_FLAGS="--coverage"			\
@@ -33,7 +33,7 @@ build_package()
     ALLOW_TESTSUITE_FAILURE=${ALLOW_TESTSUITE_FAILURE:-false}
     make test || ${ALLOW_TESTSUITE_FAILURE}
 
-    if [[ ";${DO_CPPCHECK_ON_BRANCH};" == *";${TRAVIS_BRANCH};"* ]]; then
+    if [[ ";${DO_CPPCHECK_ON_BRANCH};" == *";${CI_BRANCH};"* ]]; then
       cppcheck --quiet --enable=all \
         -I $root_dir/src -I $root_dir/tests -I $root_dir/include \
         -I $root_dir/tests/shared-tests \

--- a/common.sh
+++ b/common.sh
@@ -227,6 +227,15 @@ setup_ci_env
 export CMAKE_VERBOSE_MAKEFILE=1
 export CTEST_OUTPUT_ON_FAILURE=1
 
+# Add default DO_*_ON_BRANCH if needed
+if [ -z ${DO_COVERAGE_ON_BRANCH+} ]; then
+  export DO_COVERAGE_ON_BRANCH=${CI_BRANCH}
+fi
+
+if [ -z ${DO_CPPCHECK_ON_BRANCH+} ]; then
+  export DO_CPPCHECK_ON_BRANCH=${CI_BRANCH}
+fi
+
 # Create layout.
 mkdir -p "$build_dir"
 mkdir -p "$install_dir"


### PR DESCRIPTION
Coverage and cppcheck considerably increase the compilation time. I suggest to make both optional of the current branch.

It is then necessary to specify DO_COVERAGE_ON_BRANCH or DO_CPPCHECK_ON_BRANCH in the global export of the travis configuration file.