### PR TITLE
Improve AppVeyor interface

### DIFF
--- a/functions.ps1
+++ b/functions.ps1
@@ -81,7 +81,8 @@ function install_git_dependencies
     # For projects that use cmake_add_subfortran directory this removes sh.exe
     # from the path
     $Env:Path = $Env:Path -replace "Git","dummy"
-    cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DPYTHON_BINDING=OFF -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN"
+    cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DPYTHON_BINDING=OFF -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN" -DGIT="C:/Program Files/Git/cmd/git.exe"
+
     if ($lastexitcode -ne 0){ exit $lastexitcode }
     msbuild INSTALL.vcxproj /p:Configuration=Debug
     if ($lastexitcode -ne 0){ exit $lastexitcode }
@@ -105,7 +106,7 @@ function build_project
   cd build
   # See comment in dependencies regarding $Env:Path manipulation
   $Env:Path = $Env:Path -replace "Git","dummy"
-  cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DPYTHON_BINDING=OFF -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN"
+  cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DPYTHON_BINDING=OFF -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN" -DGIT="C:/Program Files/Git/cmd/git.exe"
   if ($lastexitcode -ne 0){ exit $lastexitcode }
   msbuild INSTALL.vcxproj /p:Configuration=Debug
   if ($lastexitcode -ne 0){ exit $lastexitcode }

--- a/functions.ps1
+++ b/functions.ps1
@@ -83,7 +83,7 @@ function install_git_dependencies
     $Env:Path = $Env:Path -replace "Git","dummy"
     cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DPYTHON_BINDING=OFF -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN"
     if ($lastexitcode -ne 0){ exit $lastexitcode }
-    msbuild INSTALL.vcxproj
+    msbuild INSTALL.vcxproj /p:Configuration=Debug
     if ($lastexitcode -ne 0){ exit $lastexitcode }
     # Reverse our dirty work
     $Env:Path = $Env:Path -replace "dummy","Git"
@@ -107,7 +107,7 @@ function build_project
   $Env:Path = $Env:Path -replace "Git","dummy"
   cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DPYTHON_BINDING=OFF -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN"
   if ($lastexitcode -ne 0){ exit $lastexitcode }
-  msbuild INSTALL.vcxproj
+  msbuild INSTALL.vcxproj /p:Configuration=Debug
   if ($lastexitcode -ne 0){ exit $lastexitcode }
   $Env:Path = $Env:Path -replace "dummy","Git"
 }
@@ -116,7 +116,7 @@ function test_project
 {
   cd %PROJECT_SOURCE_DIR%/build
   ctest -N
-  ctest --build-config Release --exclude-regex example
+  ctest --build-config Debug --exclude-regex example
   if ($lastexitcode -ne 0)
   {
     type Testing/Temporary/LastTest.log

--- a/functions.ps1
+++ b/functions.ps1
@@ -62,7 +62,7 @@ function install_choco_dependencies
 {
   ForEach($choco_dep in $Env:CHOCO_DEPENDENCIES.split(' '))
   {
-    choco install $choco_dep
+    choco install $choco_dep -y
   }
 }
 

--- a/functions.ps1
+++ b/functions.ps1
@@ -105,3 +105,15 @@ function build_project
   msbuild INSTALL.vcxproj
   $Env:Path = $Env:Path -replace "dummy","Git"
 }
+
+function test_project
+{
+  cd %PROJECT_SOURCE_DIR%/build
+  ctest -N
+  ctest --build-config Release --exclude-regex example
+  if ($lastexitcode -ne 0)
+  {
+    type Testing/Temporary/LastTest.log
+    exit $lastexitcode
+  }
+}

--- a/functions.ps1
+++ b/functions.ps1
@@ -75,13 +75,16 @@ function install_git_dependencies
     git clone -b "$git_dep_branch" "$git_dep_uri" "$git_dep"
     cd $git_dep
     git submodule update --init
+    if ($lastexitcode -ne 0){ exit $lastexitcode }
     md build
     cd build
     # For projects that use cmake_add_subfortran directory this removes sh.exe
     # from the path
     $Env:Path = $Env:Path -replace "Git","dummy"
     cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DPYTHON_BINDING=OFF -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN"
+    if ($lastexitcode -ne 0){ exit $lastexitcode }
     msbuild INSTALL.vcxproj
+    if ($lastexitcode -ne 0){ exit $lastexitcode }
     # Reverse our dirty work
     $Env:Path = $Env:Path -replace "dummy","Git"
   }
@@ -97,12 +100,15 @@ function build_project
 {
   cd $Env:PROJECT_SOURCE_DIR
   git submodule update --init
+  if ($lastexitcode -ne 0){ exit $lastexitcode }
   md build
   cd build
   # See comment in dependencies regarding $Env:Path manipulation
   $Env:Path = $Env:Path -replace "Git","dummy"
   cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DPYTHON_BINDING=OFF -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN"
+  if ($lastexitcode -ne 0){ exit $lastexitcode }
   msbuild INSTALL.vcxproj
+  if ($lastexitcode -ne 0){ exit $lastexitcode }
   $Env:Path = $Env:Path -replace "dummy","Git"
 }
 


### PR DESCRIPTION
- Add unit tests
- Compile in Debug

Note: 84d1393b0 removes the environment modification. This change of path removed the access to git.exe. This was a problem for calls to `git -describe`, required to have correct data in the pkg-config files.