### PR TITLE
AppVeyor support improvement

### DIFF
--- a/appveyor.yml.in
+++ b/appveyor.yml.in
@@ -6,6 +6,10 @@ clone_folder: C:/devel-src/@PROJECT_NAME@
 # with your build
 # init:
 # - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+# Change this to match your desired configurations
+configuration:
+  - Debug
+  - RelWithDebInfo
 environment:
   CI_OS_NAME: win32
   CI_TOOL: appveyor
@@ -17,16 +21,14 @@ environment:
 # Do not tinker with the variables below unless you know what you are doing
   SOURCE_FOLDER: C:/devel-src
   CMAKE_INSTALL_PREFIX: C:/devel
-  PATH: C:/devel/bin;C:\Libraries\boost_1_59_0\lib64-msvc-14.0;C:\msys64\mingw64\bin;%PATH%
+  PATH: C:\Python36-x64;C:\Python36-x64\Scripts;C:/devel/bin;C:\Libraries\boost_1_67_0\lib64-msvc-14.0;%PATH%
   PKG_CONFIG_PATH: C:/devel/lib/pkgconfig
-  BOOST_ROOT: C:\Libraries\boost_1_59_0
-  BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14.0
+  BOOST_ROOT: C:\Libraries\boost_1_67_0
+  BOOST_LIBRARYDIR: C:\Libraries\boost_1_67_0\lib64-msvc-14.0
   MINGW_GFORTRAN: C:\msys64\mingw64\bin\gfortran.exe
 # N.B: empty lines here and in test_script are VERY important
 build_script:
 - ps: >-
-    Set-PSDebug -Trace 1
-
     . ./.jrl-ci/functions.ps1
 
     setup_build
@@ -37,10 +39,10 @@ build_script:
 
     build_project
 test_script:
-- cmd: >-
-    cd %PROJECT_SOURCE_DIR%
+- ps: >-
+    . ./.travis/functions.ps1
 
-    ctest
+    test_project
 # Similar to the init script, this gives access to a remote desktop session
 # after the build finished, the session is locked until you login to delete a
 # file on the dekstop, useful for debugging

--- a/functions.ps1
+++ b/functions.ps1
@@ -81,10 +81,10 @@ function install_git_dependencies
     # For projects that use cmake_add_subfortran directory this removes sh.exe
     # from the path
     $Env:Path = $Env:Path -replace "Git","dummy"
-    cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DPYTHON_BINDING=OFF -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN" -DGIT="C:/Program Files/Git/cmd/git.exe"
+    cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN" -DGIT="C:/Program Files/Git/cmd/git.exe" ${Env:CMAKE_ADDITIONAL_OPTIONS}
 
     if ($lastexitcode -ne 0){ exit $lastexitcode }
-    msbuild INSTALL.vcxproj /p:Configuration=Debug
+    msbuild INSTALL.vcxproj /p:Configuration=${Env:CONFIGURATION}
     if ($lastexitcode -ne 0){ exit $lastexitcode }
     # Reverse our dirty work
     $Env:Path = $Env:Path -replace "dummy","Git"
@@ -106,9 +106,9 @@ function build_project
   cd build
   # See comment in dependencies regarding $Env:Path manipulation
   $Env:Path = $Env:Path -replace "Git","dummy"
-  cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DPYTHON_BINDING=OFF -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN" -DGIT="C:/Program Files/Git/cmd/git.exe"
+  cmake ../ -G "Visual Studio 14 2015 Win64" -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN" -DGIT="C:/Program Files/Git/cmd/git.exe" ${Env:CMAKE_ADDITIONAL_OPTIONS}
   if ($lastexitcode -ne 0){ exit $lastexitcode }
-  msbuild INSTALL.vcxproj /p:Configuration=Debug
+  msbuild INSTALL.vcxproj /p:Configuration=${Env:CONFIGURATION}
   if ($lastexitcode -ne 0){ exit $lastexitcode }
   $Env:Path = $Env:Path -replace "dummy","Git"
 }
@@ -117,7 +117,7 @@ function test_project
 {
   cd %PROJECT_SOURCE_DIR%/build
   ctest -N
-  ctest --build-config Debug --exclude-regex example
+  ctest --build-config ${Env:CONFIGURATION} --exclude-regex example
   if ($lastexitcode -ne 0)
   {
     type Testing/Temporary/LastTest.log


### PR DESCRIPTION
Add support for two environment variables:
- `${Env:CONFIGURATION}` to handle desired build configuration (removed hard-coded `Debug` value)
- `${Env:CMAKE_ADDITIONAL_OPTIONS}` in line with the travis option

The sample script is also updated to:
- update the Boost path (`1.59` is not on the current `Visual Studio 2015`)
- the `os` key has been updated to `image`
- add the matching Python and pip version (3.6) to the path