### PR TITLE
catkin: remove reference to catkin_init_workspace

### DIFF
--- a/build
+++ b/build
@@ -137,7 +137,6 @@ build_catkin_package()
     CATKIN_WORKSPACE=$build_dir/..
     ln -s $root_dir/.. $CATKIN_WORKSPACE/src
     cd $CATKIN_WORKSPACE/src
-    catkin_init_workspace
 
     cd $CATKIN_WORKSPACE
     catkin_make


### PR DESCRIPTION
This function call is no more required. See https://answers.ros.org/question/187084/what-does-the-command-catkin_init_workspace-do/ for further explanations.