### PR TITLE
AppVeyor improvments

### DIFF
--- a/functions.ps1
+++ b/functions.ps1
@@ -1,5 +1,6 @@
-function set_cmake_generator
+function set_cmake_options
 {
+  # Set CMAKE_GENERATOR according to the build image
   if($Env:APPVEYOR_BUILD_WORKER_IMAGE -eq "Visual Studio 2017")
   {
     $Env:CMAKE_GENERATOR = "Visual Studio 15 2017 Win64";
@@ -11,6 +12,11 @@ function set_cmake_generator
   else
   {
     $Env:CMAKE_GENERATOR = "Visual Studio 12 2013 Win64";
+  }
+  # Disable Python bindings in Debug builds
+  if($Env:CONFIGURATION -eq "Debug")
+  {
+    $Env:CMAKE_ADDITIONAL_OPTIONS = "-DPYTHON_BINDING=OFF $Env:CMAKE_ADDITIONAL_OPTIONS";
   }
 }
 
@@ -70,7 +76,7 @@ function setup_pkg_config
 
 function setup_build
 {
-  set_cmake_generator
+  set_cmake_options
   setup_directories
   setup_pkg_config
 }

--- a/functions.ps1
+++ b/functions.ps1
@@ -104,7 +104,7 @@ function install_git_dependencies
     # For projects that use cmake_add_subfortran directory this removes sh.exe
     # from the path
     $Env:Path = $Env:Path -replace "Git","dummy"
-    cmake ../ -G $Env:CMAKE_GENERATOR -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN" -DGIT="C:/Program Files/Git/cmd/git.exe" ${Env:CMAKE_ADDITIONAL_OPTIONS}
+    cmake ../ -G $Env:CMAKE_GENERATOR -DCMAKE_INSTALL_PREFIX="${Env:CMAKE_INSTALL_PREFIX}" -DMINGW_GFORTRAN="$env:MINGW_GFORTRAN" -DGIT="C:/Program Files/Git/cmd/git.exe" -DBUILD_TESTING=OFF ${Env:CMAKE_ADDITIONAL_OPTIONS}
 
     if ($lastexitcode -ne 0){ exit $lastexitcode }
     msbuild INSTALL.vcxproj /p:Configuration=${Env:CONFIGURATION}


### PR DESCRIPTION
* Skip Python bindings build in Debug (requires a Python Debug install)
* Skip dependencies tests buid