### PR TITLE
[dependencies] Update Eigen download URL

### DIFF
--- a/dependencies/eigen-3.2.ps1
+++ b/dependencies/eigen-3.2.ps1
@@ -2,9 +2,9 @@ $EIGEN_VERSION="3.2.8"
 $EIGEN_HASH="07105f7124f9"
 
 cd $Env:SOURCE_FOLDER
-appveyor DownloadFile "http://bitbucket.org/eigen/eigen/get/$EIGEN_VERSION.zip"
+appveyor DownloadFile "https://github.com/eigenteam/eigen-git-mirror/archive/${EIGEN_VERSION}.zip"
 7z x "${EIGEN_VERSION}.zip" -o"${Env:SOURCE_FOLDER}\eigen" -r
-cd "${Env:SOURCE_FOLDER}\eigen\eigen-eigen-$EIGEN_HASH"
+cd "${Env:SOURCE_FOLDER}\eigen\eigen-git-mirror-${EIGEN_VERSION}"
 md build
 cd build
 

--- a/dependencies/eigen-3.3.ps1
+++ b/dependencies/eigen-3.3.ps1
@@ -2,9 +2,9 @@ $EIGEN_VERSION="3.3.7"
 $EIGEN_HASH="323c052e1731"
 
 cd $Env:SOURCE_FOLDER
-appveyor DownloadFile "http://bitbucket.org/eigen/eigen/get/$EIGEN_VERSION.zip"
+appveyor DownloadFile "https://github.com/eigenteam/eigen-git-mirror/archive/${EIGEN_VERSION}.zip"
 7z x "${EIGEN_VERSION}.zip" -o"${Env:SOURCE_FOLDER}\eigen" -r
-cd "${Env:SOURCE_FOLDER}\eigen\eigen-eigen-$EIGEN_HASH"
+cd "${Env:SOURCE_FOLDER}\eigen\eigen-git-mirror-${EIGEN_VERSION}"
 md build
 cd build
 

--- a/dependencies/eigen-common.sh
+++ b/dependencies/eigen-common.sh
@@ -4,16 +4,18 @@
 #
 . `dirname $0`/../common.sh
 
+set -x
+
 EIGEN_VERSION=$1
 EIGEN_HASH=$2
 
 # Checkout Eigen
 cd "$build_dir"
-wget --quiet "http://bitbucket.org/eigen/eigen/get/${EIGEN_VERSION}.tar.gz"
+wget "https://github.com/eigenteam/eigen-git-mirror/archive/${EIGEN_VERSION}.tar.gz"
 tar xzf ${EIGEN_VERSION}.tar.gz
-cd "$build_dir/eigen-eigen-${EIGEN_HASH}/"
-mkdir -p "$build_dir/eigen-eigen-${EIGEN_HASH}/_build"
-cd "$build_dir/eigen-eigen-${EIGEN_HASH}/_build"
+EIGEN_DIR="$build_dir/eigen-git-mirror-${EIGEN_VERSION}/"
+mkdir -p "${EIGEN_DIR}/_build"
+cd "${EIGEN_DIR}/_build"
 
 # Build, make and install Eigen
 cmake .. -DCMAKE_INSTALL_PREFIX:STRING="$install_dir"


### PR DESCRIPTION
Since Eigen is migrating from bitbucket the bitbucket URLs are no longer valid. It seems they have not fully migrated to gitlab.com yet so the github mirror URL will do for now